### PR TITLE
Replace "on :local" with "run_locally"

### DIFF
--- a/lib/capistrano/net_storage/archiver/tar_gzip.rb
+++ b/lib/capistrano/net_storage/archiver/tar_gzip.rb
@@ -6,14 +6,14 @@ class Capistrano::NetStorage::Archiver::TarGzip < Capistrano::NetStorage::Archiv
   include Capistrano::NetStorage::Utils
 
   def check
-    on :local do
+    run_locally do
       execute :which, 'tar'
     end
   end
 
   def archive
     c = config
-    on :local do
+    run_locally do
       within c.local_release_path do
         execute :tar, 'czf', c.local_archive_path, '.'
       end

--- a/lib/capistrano/net_storage/archiver/zip.rb
+++ b/lib/capistrano/net_storage/archiver/zip.rb
@@ -6,14 +6,14 @@ class Capistrano::NetStorage::Archiver::Zip < Capistrano::NetStorage::Archiver::
   include Capistrano::NetStorage::Utils
 
   def check
-    on :local do
+    run_locally do
       execute :which, 'zip'
     end
   end
 
   def archive
     c = config
-    on :local do
+    run_locally do
       within c.local_release_path do
         execute :zip, c.local_archive_path, '-r', '.'
       end

--- a/lib/capistrano/net_storage/bundler.rb
+++ b/lib/capistrano/net_storage/bundler.rb
@@ -7,7 +7,7 @@ module Capistrano
       include Capistrano::NetStorage::Utils
 
       def check
-        on :local do
+        run_locally do
           execute :which, 'bundle'
         end
       end
@@ -15,7 +15,7 @@ module Capistrano
       # Do bundle install locally. Installed gems are to be included to the release.
       def install
         c = config
-        on :local do
+        run_locally do
           local_release_bundle_path = c.local_release_path.join('vendor', 'bundle')
           execute :mkdir, '-p', local_release_bundle_path
           execute :mkdir, '-p', "#{c.local_release_path}/.bundle"

--- a/lib/capistrano/net_storage/cleaner.rb
+++ b/lib/capistrano/net_storage/cleaner.rb
@@ -11,7 +11,7 @@ module Capistrano
       # @see Capistrano::NetStorage::Config#local_releases_path
       def cleanup_local_release
         c = config
-        on :local do
+        run_locally do
           releases = capture(:ls, '-xtr', c.local_releases_path).split
           # Contains archive files and extracted directories
           if releases.count > fetch(:keep_releases) * 2

--- a/lib/capistrano/net_storage/scm/git.rb
+++ b/lib/capistrano/net_storage/scm/git.rb
@@ -3,14 +3,14 @@ require 'capistrano/net_storage/scm/base'
 # Internal SCM class for Git repository
 class Capistrano::NetStorage::SCM::Git < Capistrano::NetStorage::SCM::Base
   def check
-    on :local do
+    run_locally do
       execute :git, 'ls-remote', repo_url, 'HEAD'
     end
   end
 
   def clone
     c = config
-    on :local do
+    run_locally do
       if File.exist?("#{c.local_mirror_path}/HEAD")
         info t(:mirror_exists, at: c.local_mirror_path)
       else
@@ -21,7 +21,7 @@ class Capistrano::NetStorage::SCM::Git < Capistrano::NetStorage::SCM::Base
 
   def update
     c = config
-    on :local do
+    run_locally do
       within c.local_mirror_path do
         execute :git, :remote, :update
       end
@@ -31,7 +31,7 @@ class Capistrano::NetStorage::SCM::Git < Capistrano::NetStorage::SCM::Base
   def set_current_revision
     return if fetch(:current_revision)
     c = config
-    on :local do
+    run_locally do
       within c.local_mirror_path do
         set :current_revision, capture(:git, "rev-parse #{fetch(:branch)}")
       end
@@ -40,7 +40,7 @@ class Capistrano::NetStorage::SCM::Git < Capistrano::NetStorage::SCM::Base
 
   def prepare_archive
     c = config
-    on :local do
+    run_locally do
       execute :mkdir, '-p', c.local_release_path
 
       within c.local_mirror_path do

--- a/lib/capistrano/net_storage/utils.rb
+++ b/lib/capistrano/net_storage/utils.rb
@@ -28,7 +28,7 @@ module Capistrano
           if c.upload_files_by_rsync?
             Parallel.each(c.servers, in_threads: c.max_parallels) do |host|
               ssh = build_ssh_command(host)
-              on :local do
+              run_locally do
                 execute :rsync, "-az --rsh='#{ssh}' #{src} #{host}:#{dest}"
               end
             end

--- a/lib/capistrano/tasks/net_storage.rake
+++ b/lib/capistrano/tasks/net_storage.rake
@@ -94,7 +94,7 @@ namespace :net_storage do
         config.local_releases_path,
       ]
       dirs << config.local_bundle_path unless config.skip_bundle?
-      on :local do
+      run_locally do
         dirs.each { |dir| execute :mkdir, '-p', dir }
       end
     end


### PR DESCRIPTION
As for [sshkit/EXAMPLES.md](https://github.com/capistrano/sshkit/blob/master/EXAMPLES.md), `on :local` and `run_locally` seem compatiable.

But actually, `on :local` does not work on some conditions.
In that situation the codes inside `on :local` block are not run at all.

Here is the spec of my environment to reproduce this situation:

- Linux CentOS 6.x
- rbenv ruby v2.3.x
- capistrano v3.5.0 & v3.6.1

On the other hand, `run_locally` has no problem.

So I push this change.