### PR TITLE
Use rev-list instead of rev-parse in cases like annotated tag

### DIFF
--- a/lib/capistrano/net_storage/scm/git.rb
+++ b/lib/capistrano/net_storage/scm/git.rb
@@ -33,7 +33,7 @@ class Capistrano::NetStorage::SCM::Git < Capistrano::NetStorage::SCM::Base
     c = config
     run_locally do
       within c.local_mirror_path do
-        set :current_revision, capture(:git, "rev-parse #{fetch(:branch)}")
+        set :current_revision, capture(:git, "rev-list --max-count=1 #{fetch(:branch)}")
       end
     end
   end


### PR DESCRIPTION
I would like to use `rev-list` for annotated git tags.

This was originally introduced in https://github.com/capistrano/capistrano/pull/1339 and `--max-count=1`
is the only option used in the latest v3.8.1.

https://github.com/capistrano/capistrano/blob/v3.8.1/lib/capistrano/scm/git.rb#L72