### PR TITLE
Enable HOSTS settings when using cap deploy --hosts xxx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 
 # rspec failure tracking
 .rspec_status
+vendor

--- a/lib/capistrano/net_storage/archiver/tar_gzip.rb
+++ b/lib/capistrano/net_storage/archiver/tar_gzip.rb
@@ -22,7 +22,8 @@ class Capistrano::NetStorage::Archiver::TarGzip < Capistrano::NetStorage::Archiv
 
   def extract
     c = config
-    on c.servers, in: :groups, limit: c.max_parallels do
+    hosts = ::Capistrano::Configuration.env.filter(c.servers)
+    on hosts, in: :groups, limit: c.max_parallels do
       execute :mkdir, '-p', release_path
       within release_path do
         execute :tar, 'xzf', c.archive_path

--- a/lib/capistrano/net_storage/archiver/zip.rb
+++ b/lib/capistrano/net_storage/archiver/zip.rb
@@ -22,7 +22,8 @@ class Capistrano::NetStorage::Archiver::Zip < Capistrano::NetStorage::Archiver::
 
   def extract
     c = config
-    on c.servers, in: :groups, limit: c.max_parallels do
+    hosts = ::Capistrano::Configuration.env.filter(c.servers)
+    on hosts, in: :groups, limit: c.max_parallels do
       execute :unzip, c.archive_path, '-d', release_path
       execute :rm, '-f', c.archive_path
     end

--- a/lib/capistrano/net_storage/bundler.rb
+++ b/lib/capistrano/net_storage/bundler.rb
@@ -41,8 +41,8 @@ module Capistrano
       # Create +.bundle/config+ at release path on remote servers
       def sync_config
         c = config
-
-        on c.servers, in: :groups, limit: c.max_parallels do
+        hosts = ::Capistrano::Configuration.env.filter(c.servers)
+        on hosts, in: :groups, limit: c.max_parallels do
           within release_path do
             execute :mkdir, '-p', '.bundle'
           end


### PR DESCRIPTION
Fix reflecting cap command's --hosts options.

