### PR TITLE
Use currently supported Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
 sudo: false
 language: ruby
 rvm:
-- 2.0.0
-- 2.1.8
-- 2.2.0
-- 2.3.5
-- 2.4.2
+- 2.6.3
+- 2.5.5
+- 2.4.6
 
-before_install: gem install bundler -v 1.14.6
+before_install: gem install bundler
 install: bundle install
 script: bundle exec rake spec
 notifications:


### PR DESCRIPTION
ref. https://www.ruby-lang.org/en/news/2019/03/31/support-of-ruby-2-3-has-ended/