### PR TITLE
Fix issues regarding sshkit and rsync

### DIFF
--- a/capistrano-net_storage.gemspec
+++ b/capistrano-net_storage.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.0'
 
   spec.add_runtime_dependency 'capistrano', '>= 3.3.3'
-  spec.add_runtime_dependency 'parallel'
   spec.add_runtime_dependency 'bundler'
 
   spec.add_development_dependency 'rake'

--- a/lib/capistrano/net_storage/utils.rb
+++ b/lib/capistrano/net_storage/utils.rb
@@ -1,5 +1,3 @@
-require 'parallel'
-
 require 'capistrano/net_storage/base'
 
 module Capistrano

--- a/lib/capistrano/net_storage/utils.rb
+++ b/lib/capistrano/net_storage/utils.rb
@@ -18,11 +18,16 @@ module Capistrano
         c = config
         hosts = ::Capistrano::Configuration.env.filter(c.servers)
 
+        # FIXME: This is a very workaround to architectural issue. Do not copy.
+        build_rsh_option = -> (host) {
+          build_ssh_command(host)
+        }
+
         on hosts, in: :groups, limit: c.max_parallels do |host|
           if c.upload_files_by_rsync?
-            ssh = build_ssh_command(host)
+            rsh_option = build_rsh_option.call(host)
             run_locally do
-              execute :rsync, "-az --rsh='#{ssh}' #{files.join(' ')} #{host}:#{dest_dir}"
+              execute :rsync, "-az --rsh='#{rsh_option}' #{files.join(' ')} #{host.hostname}:#{dest_dir}"
             end
           else
             files.each do |src|


### PR DESCRIPTION
### Summary

Previously, Capistrano::NetStorage uses Parallel and execute multiple rsync from there.

This is not the Capistrano way of controlling deployment flow, and this is the cause of
`IOError: closed stream`

Here, I rewrite the code in Capistrano way.

Also, this includes reducing the number of executing `rsync` command,
which reduces both the time to deploy and the probability of encountering random errors.

### Other Information

When debugging this issue on our environment, we found out that not-rsyncing option did not work.
Probably, it is a good time for us to only use the `rsync`.

### Checklist

* [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).
