### PR TITLE
Support a repository with multiple Rails apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Set Capistrano variables by `set name, value`.
  `:net_storage_local_bundle_path` | `#{net_storage_local_base_path}/bundle` | Shared directory to install gems on deploy server
  `:net_storage_local_archives_path` | `#{net_storage_local_base_path}/archives` | Archive directories on deploy server
  `:net_storage_archives_path` | `#{deploy_to}/net_storage_archives` | Archive directories on application server
+ `:net_storage_multi_app_mode` | `false` | Deploy a repository with multiple Rails apps at the top directory
 
 ### Transport Plugins
 

--- a/lib/capistrano/net_storage/archiver/base.rb
+++ b/lib/capistrano/net_storage/archiver/base.rb
@@ -21,6 +21,12 @@ module Capistrano
         def extract
           raise NotImplementedError
         end
+
+        # file extension
+        # @abstract
+        def self.file_extension
+          'archive' # just for backward compatibility
+        end
       end
     end
   end

--- a/lib/capistrano/net_storage/archiver/tar_gzip.rb
+++ b/lib/capistrano/net_storage/archiver/tar_gzip.rb
@@ -30,4 +30,8 @@ class Capistrano::NetStorage::Archiver::TarGzip < Capistrano::NetStorage::Archiv
       end
     end
   end
+
+  def self.file_extension
+    'tar.gz'
+  end
 end

--- a/lib/capistrano/net_storage/archiver/zip.rb
+++ b/lib/capistrano/net_storage/archiver/zip.rb
@@ -30,4 +30,8 @@ class Capistrano::NetStorage::Archiver::Zip < Capistrano::NetStorage::Archiver::
       end
     end
   end
+
+  def self.file_extension
+    'zip'
+  end
 end

--- a/lib/capistrano/net_storage/bundler.rb
+++ b/lib/capistrano/net_storage/bundler.rb
@@ -7,22 +7,24 @@ module Capistrano
       include Capistrano::NetStorage::Utils
 
       def check
+        c = config # should be local variable
         run_locally do
           execute :which, 'bundle'
-          execute :mkdir, '-p', config.local_bundle_path
+          execute :mkdir, '-p', c.local_bundle_path
         end
       end
 
       # bundle install locally. `.bundle/config` and installed gems are to be included in the release and archive.
       def install
+        c = config # should be local variable
         run_locally do
-          within config.local_release_app_path do
+          within c.local_release_app_path do
             ::Bundler.with_clean_env do
               install_path = Pathname.new('vendor/bundle') # must be a relative path for portability between local and remote
               execute :mkdir, '-p', install_path
 
               # Sync installed gems from shared directory to speed up installation
-              execute :rsync, '-a', '--delete', "#{config.local_bundle_path}/", install_path
+              execute :rsync, '-a', '--delete', "#{c.local_bundle_path}/", install_path
 
               # Always set config
               execute :bundle, 'config', 'set', '--local', 'deployment', 'true'
@@ -34,7 +36,7 @@ module Capistrano
               execute :bundle, 'clean'
 
               # Sync back to shared directory for the next release
-              execute :rsync, '-a', '--delete', "#{install_path}/", config.local_bundle_path
+              execute :rsync, '-a', '--delete', "#{install_path}/", c.local_bundle_path
             end
           end
         end

--- a/lib/capistrano/net_storage/bundler.rb
+++ b/lib/capistrano/net_storage/bundler.rb
@@ -39,32 +39,8 @@ module Capistrano
         end
       end
 
-      # Create +.bundle/config+ at release path on remote servers
+      # Nothing is required. This methoed exists just for backward compatibility
       def sync_config
-        c = config
-
-        on c.servers, in: :groups, limit: c.max_parallels do
-          within release_path do
-            execute :mkdir, '-p', '.bundle'
-          end
-        end
-
-        run_locally do
-          execute :mkdir, '-p', "#{c.local_base_path}/.bundle"
-        end
-        bundle_config_path = "#{c.local_base_path}/.bundle/config"
-        File.open(bundle_config_path, 'w') do |file|
-          file.print(<<-EOS)
----
-BUNDLE_FROZEN: "1"
-BUNDLE_PATH: "#{release_path.join('vendor', 'bundle')}"
-BUNDLE_WITHOUT: "development:test"
-BUNDLE_DISABLE_SHARED_GEMS: "true"
-BUNDLE_BIN: "#{release_path.join('bin')}"
-EOS
-        end
-
-        upload_files([bundle_config_path], release_path.join('.bundle'))
       end
     end
   end

--- a/lib/capistrano/net_storage/bundler.rb
+++ b/lib/capistrano/net_storage/bundler.rb
@@ -12,7 +12,7 @@ module Capistrano
         end
       end
 
-      # Do bundle install locally. Installed gems are to be included to the release.
+      # bundle install locally. `.bundle/config` and installed gems are to be included in the release and archive.
       def install
         run_locally do
           local_release_bundle_path = config.local_release_path.join('vendor', 'bundle')

--- a/lib/capistrano/net_storage/bundler.rb
+++ b/lib/capistrano/net_storage/bundler.rb
@@ -18,7 +18,7 @@ module Capistrano
           within config.local_release_app_path do
             ::Bundler.with_clean_env do
               install_path = Pathname.new('vendor/bundle') # must be a relative path for portability between local and remote
-              execute :mkdir '-p', install_path
+              execute :mkdir, '-p', install_path
 
               # Sync installed gems from shared directory to speed up installation
               execute :rsync, '-a', '--delete', "#{config.local_bundle_path}/", install_path

--- a/lib/capistrano/net_storage/bundler.rb
+++ b/lib/capistrano/net_storage/bundler.rb
@@ -38,10 +38,6 @@ module Capistrano
           end
         end
       end
-
-      # Nothing is required. This methoed exists just for backward compatibility
-      def sync_config
-      end
     end
   end
 end

--- a/lib/capistrano/net_storage/bundler.rb
+++ b/lib/capistrano/net_storage/bundler.rb
@@ -25,7 +25,7 @@ module Capistrano
             ::Bundler.with_clean_env do
               # Always set config
               execute :bundle, 'config', 'set', '--local', 'deployment', 'true'
-              execute :bundle, 'config', 'set', '--local', 'path', local_release_bundle_path
+              execute :bundle, 'config', 'set', '--local', 'path', Pathname.new('vendor/bundle') # Use relative path to ease rsync
               execute :bundle, 'config', 'set', '--local', 'without', 'development test'
 
               execute :bundle, 'install', '--quiet'

--- a/lib/capistrano/net_storage/bundler.rb
+++ b/lib/capistrano/net_storage/bundler.rb
@@ -17,7 +17,7 @@ module Capistrano
         run_locally do
           within config.local_release_path do
             ::Bundler.with_clean_env do
-              install_path = Pathname.new('vendor/bundle')
+              install_path = Pathname.new('vendor/bundle') # must be a relative path for portability between local and remote
               execute :mkdir '-p', install_path
 
               # Sync installed gems from shared directory to speed up installation

--- a/lib/capistrano/net_storage/bundler.rb
+++ b/lib/capistrano/net_storage/bundler.rb
@@ -27,6 +27,7 @@ module Capistrano
               execute :bundle, 'config', 'set', '--local', 'deployment', 'true'
               execute :bundle, 'config', 'set', '--local', 'path', Pathname.new('vendor/bundle') # Use relative path to ease rsync
               execute :bundle, 'config', 'set', '--local', 'without', 'development test'
+              execute :bundle, 'config', 'set', '--local', 'disable_shared_gems', 'true'
 
               execute :bundle, 'install', '--quiet'
               execute :bundle, 'clean'

--- a/lib/capistrano/net_storage/bundler.rb
+++ b/lib/capistrano/net_storage/bundler.rb
@@ -15,7 +15,7 @@ module Capistrano
       # bundle install locally. `.bundle/config` and installed gems are to be included in the release and archive.
       def install
         run_locally do
-          within config.local_release_path do
+          within config.local_release_app_path do
             ::Bundler.with_clean_env do
               install_path = Pathname.new('vendor/bundle') # must be a relative path for portability between local and remote
               execute :mkdir '-p', install_path

--- a/lib/capistrano/net_storage/bundler.rb
+++ b/lib/capistrano/net_storage/bundler.rb
@@ -15,25 +15,25 @@ module Capistrano
       # bundle install locally. `.bundle/config` and installed gems are to be included in the release and archive.
       def install
         run_locally do
-          local_release_bundle_path = config.local_release_path.join('vendor', 'bundle')
-          execute :mkdir, '-p', local_release_bundle_path
-
-          # Copy shared gems to release bundle path beforehand to reuse installed previously
-          execute :rsync, '-a', '--delete', "#{config.local_bundle_path}/", local_release_bundle_path
-
           within config.local_release_path do
             ::Bundler.with_clean_env do
+              install_path = Pathname.new('vendor/bundle')
+              execute :mkdir '-p', install_path
+
+              # Sync installed gems from shared directory to speed up installation
+              execute :rsync, '-a', '--delete', "#{config.local_bundle_path}/", install_path
+
               # Always set config
               execute :bundle, 'config', 'set', '--local', 'deployment', 'true'
-              execute :bundle, 'config', 'set', '--local', 'path', Pathname.new('vendor/bundle') # Use relative path to ease rsync
+              execute :bundle, 'config', 'set', '--local', 'path', install_path
               execute :bundle, 'config', 'set', '--local', 'without', 'development test'
               execute :bundle, 'config', 'set', '--local', 'disable_shared_gems', 'true'
 
               execute :bundle, 'install', '--quiet'
               execute :bundle, 'clean'
 
-              # Sync installed gems to shared directory to reuse them next time
-              execute :rsync, '-a', '--delete', "#{local_release_bundle_path}/", config.local_bundle_path
+              # Sync back to shared directory for the next release
+              execute :rsync, '-a', '--delete', "#{install_path}/", config.local_bundle_path
             end
           end
         end

--- a/lib/capistrano/net_storage/bundler.rb
+++ b/lib/capistrano/net_storage/bundler.rb
@@ -9,6 +9,7 @@ module Capistrano
       def check
         run_locally do
           execute :which, 'bundle'
+          execute :mkdir, '-p', config.local_bundle_path
         end
       end
 

--- a/lib/capistrano/net_storage/config.rb
+++ b/lib/capistrano/net_storage/config.rb
@@ -91,6 +91,11 @@ module Capistrano
       # Path settings
       #
 
+      # Path to application of remote release_path
+      def release_app_path
+        @release_app_path ||= multi_app_mode? ? Pathname.new(release_path).join(fetch(:application)) : Pathname.new(release_path)
+      end
+
       # Path of base directory on local
       # @return [Pathname]
       def local_base_path
@@ -113,6 +118,11 @@ module Capistrano
       # @return [Pathname]
       def local_release_path
         @local_release_path ||= local_releases_path.join(release_timestamp)
+      end
+
+      # Path to application of local release_path
+      def local_release_app_path
+        @local_release_app_path ||= multi_app_mode? ? local_release_path.join(fetch(:application)) : local_release_path
       end
 
       # Shared directory to install gems on local

--- a/lib/capistrano/net_storage/config.rb
+++ b/lib/capistrano/net_storage/config.rb
@@ -154,6 +154,8 @@ module Capistrano
       def archive_file_extension
         executor_class(:archiver).file_extension
       end
+
+      alias archive_suffix archive_file_extension # backward compatibility
     end
   end
 end

--- a/lib/capistrano/net_storage/config.rb
+++ b/lib/capistrano/net_storage/config.rb
@@ -16,6 +16,7 @@ module Capistrano
         bundler: Capistrano::NetStorage::Bundler,
         transport: nil,
       }
+      DEFAULT_LOCAL_BASE_PATH = Pathname.new("#{Dir.pwd}/.local_repo")
 
       def executor_class(type)
         unless DEFAULT_EXECUTOR_CLASS.key?(type)
@@ -92,7 +93,7 @@ module Capistrano
       # Path of base directory on local
       # @return [Pathname]
       def local_base_path
-        Pathname.new(fetch(:net_storage_local_base_path, "#{Dir.pwd}/.local_repo"))
+        Pathname.new(fetch(:net_storage_local_base_path, DEFAULT_LOCAL_BASE_PATH))
       end
 
       # Path to clone repository on local

--- a/lib/capistrano/net_storage/config.rb
+++ b/lib/capistrano/net_storage/config.rb
@@ -48,22 +48,18 @@ module Capistrano
       # If +true+, skip to bundle gems bundled with target app.
       # Defaults to +true+
       def skip_bundle?
-        @has_checked_skip_bundle ||= begin
-          @skip_bundle = !fetch(:net_storage_with_bundle)
-          true
-        end
-        @skip_bundle
+        return @skip_bundle if instance_variable_defined? :@skip_bundle
+
+        @skip_bundle = !fetch(:net_storage_with_bundle, false) # just for backward compatibility
       end
 
       # If +true+, create archive ONLY when it's not found on remote storage.
       # Otherwise, create archive ALWAYS.
       # Defaults to +true+
       def archive_on_missing?
-        @has_checked_archive_on_missing ||= begin
-          @archive_on_missing = fetch(:net_storage_archive_on_missing, true)
-          true
-        end
-        @archive_on_missing
+        return @archive_on_missing if instance_variable_defined? :@archive_on_missing
+
+        @archive_on_missing = fetch(:net_storage_archive_on_missing, true)
       end
 
       # If +true+, use +rsync+ to sync config files.

--- a/lib/capistrano/net_storage/config.rb
+++ b/lib/capistrano/net_storage/config.rb
@@ -94,15 +94,13 @@ module Capistrano
       # Path to clone repository on local
       # @return [Pathname]
       def local_mirror_path
-        @local_mirror_path ||= Pathname.new(fetch(:net_storage_local_mirror_path))
-        @local_mirror_path ||= local_base_path.join('mirror')
+        @local_mirror_path ||= Pathname.new(fetch(:net_storage_local_mirror_path, local_base_path.join('mirror')))
       end
 
       # Path to keep release directories on local
       # @return [Pathname]
       def local_releases_path
-        @local_releases_path ||= Pathname.new(fetch(:net_storage_local_releases_path))
-        @local_releases_path ||= local_base_path.join('releases')
+        @local_releases_path ||= Pathname.new(fetch(:net_storage_local_releases_path, local_base_path.join('releases')))
       end
 
       # Path to take a snapshot of repository for release on local
@@ -114,15 +112,13 @@ module Capistrano
       # Shared directory to install gems on local
       # @return [Pathname]
       def local_bundle_path
-        @local_bundle_path ||= Pathname.new(fetch(:net_storage_local_bundle_path))
-        @local_bundle_path ||= local_base_path.join('bundle')
+        @local_bundle_path ||= Pathname.new(fetch(:net_storage_local_bundle_path, local_base_path.join('bundle')))
       end
 
       # Path of archive directories on local
       # @return [Pathname]
       def local_archives_path
-        @local_archives_path ||= Pathname.new(fetch(:net_storage_local_archives_path))
-        @local_archives_path ||= local_base_path.join('archives')
+        @local_archives_path ||= Pathname.new(fetch(:net_storage_local_archives_path, local_base_path.join('archives')))
       end
 
       # Destination path to archive application on local
@@ -134,8 +130,7 @@ module Capistrano
       # Path of archive directories on remote servers
       # @return [Pathname]
       def archives_path
-        @archives_path ||= Pathname.new(fetch(:net_storage_archives_path))
-        @archives_path ||= deploy_path.join('net_storage_archives')
+        @archives_path ||= Pathname.new(fetch(:net_storage_archives_path, deploy_path.join('net_storage_archives')))
       end
 
       # Path of archive file to be downloaded on remote servers

--- a/lib/capistrano/net_storage/config.rb
+++ b/lib/capistrano/net_storage/config.rb
@@ -123,7 +123,7 @@ module Capistrano
       # Destination path to archive application on local
       # @return [Pathname]
       def local_archive_path
-        @local_archive_path ||= local_archives_path.join("#{release_timestamp}.#{archive_suffix}")
+        @local_archive_path ||= local_archives_path.join("#{release_timestamp}.#{archive_file_extension}")
       end
 
       # Path of archive directories on remote servers
@@ -135,20 +135,13 @@ module Capistrano
       # Path of archive file to be downloaded on remote servers
       # @return [Pathname]
       def archive_path
-        @archive_path ||= archives_path.join("#{release_timestamp}.#{archive_suffix}")
+        @archive_path ||= archives_path.join("#{release_timestamp}.#{archive_file_extension}")
       end
 
       # Suffix of archive file
       # @return [String]
-      def archive_suffix
-        case Capistrano::NetStorage.archiver
-        when Capistrano::NetStorage::Archiver::Zip
-          'zip'
-        when Capistrano::NetStorage::Archiver::TarGzip
-          'tar.gz'
-        else
-          'archive'
-        end
+      def archive_file_extension
+        @archive_file_extension ||= executor_class(:archiver).file_extension
       end
     end
   end

--- a/lib/capistrano/net_storage/config.rb
+++ b/lib/capistrano/net_storage/config.rb
@@ -80,6 +80,13 @@ module Capistrano
         @rsync_options ||= fetch(:net_storage_rsync_options, fetch(:ssh_options, {}))
       end
 
+      # If your repository consists of multiple Rails apps, you can enable this for seamless deployment
+      def multi_app_mode?
+        return @multi_app_mode if instance_variable_defined? :@multi_app_mode
+
+        @multi_app_mode = fetch(:net_storage_multi_app_mode, false)
+      end
+
       #
       # Path settings
       #

--- a/lib/capistrano/net_storage/config.rb
+++ b/lib/capistrano/net_storage/config.rb
@@ -22,8 +22,7 @@ module Capistrano
           raise ArgumentError, "Invalid type specified: #{type.inspect}"
         end
 
-        @executor_class ||= {}
-        @executor_class[type] ||= fetch(:"net_storage_#{type}") do
+        fetch(:"net_storage_#{type}") do
           default = DEFAULT_EXECUTOR_CLASS[type]
           unless default
             raise ArgumentError, "You have to `set(:net_storage_#{type}, CustomClass)`"
@@ -39,30 +38,26 @@ module Capistrano
       end
 
       def max_parallels
-        @max_parallels ||= fetch(:net_storage_max_parallels, servers.size)
+        fetch(:net_storage_max_parallels, servers.size)
       end
 
       # Application configuration files to be deployed with
       # @return [Array<String, Pathname>]
       def config_files
-        @config_files ||= fetch(:net_storage_config_files)
+        fetch(:net_storage_config_files)
       end
 
       # If +true+, skip to bundle gems bundled with target app.
       # Defaults to +true+
       def skip_bundle?
-        return @skip_bundle if instance_variable_defined? :@skip_bundle
-
-        @skip_bundle = !fetch(:net_storage_with_bundle, false) # just for backward compatibility
+        !fetch(:net_storage_with_bundle, false) # just for backward compatibility
       end
 
       # If +true+, create archive ONLY when it's not found on remote storage.
       # Otherwise, create archive ALWAYS.
       # Defaults to +true+
       def archive_on_missing?
-        return @archive_on_missing if instance_variable_defined? :@archive_on_missing
-
-        @archive_on_missing = fetch(:net_storage_archive_on_missing, true)
+        fetch(:net_storage_archive_on_missing, true)
       end
 
       # If +true+, use +rsync+ to sync config files.
@@ -70,21 +65,19 @@ module Capistrano
       # Defaults to +false+
       # @see #rsync_options
       def upload_files_by_rsync?
-        @upload_files_by_rsync ||= fetch(:net_storage_upload_files_by_rsync, false)
+        fetch(:net_storage_upload_files_by_rsync, false)
       end
 
       # You can set +:user+, +:keys+, +:port+ as ssh options for +rsync+ command to sync configs
       # when +:net_storage_upload_files_by_rsync+ is set +true+.
       # @see #upload_files_by_rsync?
       def rsync_options
-        @rsync_options ||= fetch(:net_storage_rsync_options, fetch(:ssh_options, {}))
+        fetch(:net_storage_rsync_options, fetch(:ssh_options, {}))
       end
 
       # If your repository consists of multiple Rails apps, you can enable this for seamless deployment
       def multi_app_mode?
-        return @multi_app_mode if instance_variable_defined? :@multi_app_mode
-
-        @multi_app_mode = fetch(:net_storage_multi_app_mode, false)
+        fetch(:net_storage_multi_app_mode, false)
       end
 
       #
@@ -93,72 +86,72 @@ module Capistrano
 
       # Path to application of remote release_path
       def release_app_path
-        @release_app_path ||= multi_app_mode? ? Pathname.new(release_path).join(fetch(:application)) : Pathname.new(release_path)
+        multi_app_mode? ? Pathname.new(release_path).join(fetch(:application)) : Pathname.new(release_path)
       end
 
       # Path of base directory on local
       # @return [Pathname]
       def local_base_path
-        @local_base_path ||= Pathname.new(fetch(:net_storage_local_base_path, "#{Dir.pwd}/.local_repo"))
+        Pathname.new(fetch(:net_storage_local_base_path, "#{Dir.pwd}/.local_repo"))
       end
 
       # Path to clone repository on local
       # @return [Pathname]
       def local_mirror_path
-        @local_mirror_path ||= Pathname.new(fetch(:net_storage_local_mirror_path, local_base_path.join('mirror')))
+        Pathname.new(fetch(:net_storage_local_mirror_path, local_base_path.join('mirror')))
       end
 
       # Path to keep release directories on local
       # @return [Pathname]
       def local_releases_path
-        @local_releases_path ||= Pathname.new(fetch(:net_storage_local_releases_path, local_base_path.join('releases')))
+        Pathname.new(fetch(:net_storage_local_releases_path, local_base_path.join('releases')))
       end
 
       # Path to take a snapshot of repository for release on local
       # @return [Pathname]
       def local_release_path
-        @local_release_path ||= local_releases_path.join(release_timestamp)
+        local_releases_path.join(release_timestamp)
       end
 
       # Path to application of local release_path
       def local_release_app_path
-        @local_release_app_path ||= multi_app_mode? ? local_release_path.join(fetch(:application)) : local_release_path
+        multi_app_mode? ? local_release_path.join(fetch(:application)) : local_release_path
       end
 
       # Shared directory to install gems on local
       # @return [Pathname]
       def local_bundle_path
-        @local_bundle_path ||= Pathname.new(fetch(:net_storage_local_bundle_path, local_base_path.join('bundle')))
+        Pathname.new(fetch(:net_storage_local_bundle_path, local_base_path.join('bundle')))
       end
 
       # Path of archive directories on local
       # @return [Pathname]
       def local_archives_path
-        @local_archives_path ||= Pathname.new(fetch(:net_storage_local_archives_path, local_base_path.join('archives')))
+        Pathname.new(fetch(:net_storage_local_archives_path, local_base_path.join('archives')))
       end
 
       # Destination path to archive application on local
       # @return [Pathname]
       def local_archive_path
-        @local_archive_path ||= local_archives_path.join("#{release_timestamp}.#{archive_file_extension}")
+        local_archives_path.join("#{release_timestamp}.#{archive_file_extension}")
       end
 
       # Path of archive directories on remote servers
       # @return [Pathname]
       def archives_path
-        @archives_path ||= Pathname.new(fetch(:net_storage_archives_path, deploy_path.join('net_storage_archives')))
+        Pathname.new(fetch(:net_storage_archives_path, deploy_path.join('net_storage_archives')))
       end
 
       # Path of archive file to be downloaded on remote servers
       # @return [Pathname]
       def archive_path
-        @archive_path ||= archives_path.join("#{release_timestamp}.#{archive_file_extension}")
+        archives_path.join("#{release_timestamp}.#{archive_file_extension}")
       end
 
       # Suffix of archive file
       # @return [String]
       def archive_file_extension
-        @archive_file_extension ||= executor_class(:archiver).file_extension
+        executor_class(:archiver).file_extension
       end
     end
   end

--- a/lib/capistrano/net_storage/config.rb
+++ b/lib/capistrano/net_storage/config.rb
@@ -1,3 +1,5 @@
+require 'pathname'
+
 require 'capistrano/net_storage/error'
 require 'capistrano/net_storage/bundler'
 require 'capistrano/net_storage/archiver/zip'
@@ -86,20 +88,20 @@ module Capistrano
       # Path of base directory on local
       # @return [Pathname]
       def local_base_path
-        @local_base_path ||= pathname(fetch(:net_storage_local_base_path, "#{Dir.pwd}/.local_repo"))
+        @local_base_path ||= Pathname.new(fetch(:net_storage_local_base_path, "#{Dir.pwd}/.local_repo"))
       end
 
       # Path to clone repository on local
       # @return [Pathname]
       def local_mirror_path
-        @local_mirror_path ||= pathname(fetch(:net_storage_local_mirror_path))
+        @local_mirror_path ||= Pathname.new(fetch(:net_storage_local_mirror_path))
         @local_mirror_path ||= local_base_path.join('mirror')
       end
 
       # Path to keep release directories on local
       # @return [Pathname]
       def local_releases_path
-        @local_releases_path ||= pathname(fetch(:net_storage_local_releases_path))
+        @local_releases_path ||= Pathname.new(fetch(:net_storage_local_releases_path))
         @local_releases_path ||= local_base_path.join('releases')
       end
 
@@ -112,14 +114,14 @@ module Capistrano
       # Shared directory to install gems on local
       # @return [Pathname]
       def local_bundle_path
-        @local_bundle_path ||= pathname(fetch(:net_storage_local_bundle_path))
+        @local_bundle_path ||= Pathname.new(fetch(:net_storage_local_bundle_path))
         @local_bundle_path ||= local_base_path.join('bundle')
       end
 
       # Path of archive directories on local
       # @return [Pathname]
       def local_archives_path
-        @local_archives_path ||= pathname(fetch(:net_storage_local_archives_path))
+        @local_archives_path ||= Pathname.new(fetch(:net_storage_local_archives_path))
         @local_archives_path ||= local_base_path.join('archives')
       end
 
@@ -132,7 +134,7 @@ module Capistrano
       # Path of archive directories on remote servers
       # @return [Pathname]
       def archives_path
-        @archives_path ||= pathname(fetch(:net_storage_archives_path))
+        @archives_path ||= Pathname.new(fetch(:net_storage_archives_path))
         @archives_path ||= deploy_path.join('net_storage_archives')
       end
 
@@ -152,17 +154,6 @@ module Capistrano
           'tar.gz'
         else
           'archive'
-        end
-      end
-
-      private
-
-      def pathname(path)
-        case path
-        when String
-          Pathname.new(path)
-        else
-          path
         end
       end
     end

--- a/lib/capistrano/net_storage/coordinator.rb
+++ b/lib/capistrano/net_storage/coordinator.rb
@@ -8,30 +8,23 @@ module Capistrano
       end
 
       def archiver
-        load_executor(:archiver)
+        config.executor_class(:archiver).new
       end
 
       def transport
-        load_executor(:transport)
+        config.executor_class(:transport).new
       end
 
       def cleaner
-        load_executor(:cleaner)
+        config.executor_class(:cleaner).new
       end
 
       def bundler
-        load_executor(:bundler)
+        config.executor_class(:bundler).new
       end
 
       def scm
-        load_executor(:scm)
-      end
-
-      private
-
-      def load_executor(type)
-        @executors ||= {}
-        @executors[type] ||= config.executor_class(type).new
+        config.executor_class(:scm).new
       end
     end
   end

--- a/lib/capistrano/net_storage/scm/base.rb
+++ b/lib/capistrano/net_storage/scm/base.rb
@@ -41,7 +41,8 @@ module Capistrano
         # Copy local config files to servers
         def sync_config
           return unless config.config_files
-          upload_files(config.config_files, release_path.join('config'))
+
+          upload_files(config.config_files, config.release_app_path.join('config'))
         end
       end
     end

--- a/lib/capistrano/net_storage/scm/base.rb
+++ b/lib/capistrano/net_storage/scm/base.rb
@@ -40,7 +40,7 @@ module Capistrano
 
         # Copy local config files to servers
         def sync_config
-          return unless config.config_files
+          return unless config.config_files&.any?
 
           upload_files(config.config_files, config.release_app_path.join('config'))
         end

--- a/lib/capistrano/tasks/net_storage.rake
+++ b/lib/capistrano/tasks/net_storage.rake
@@ -110,14 +110,16 @@ namespace :net_storage do
 
     task :directories do
       config = Capistrano::NetStorage.config
-      dirs = [
-        config.local_base_path,
-        config.local_mirror_path,
-        config.local_releases_path,
-        config.local_archives_path,
-      ]
+
       run_locally do
-        dirs.each { |dir| execute :mkdir, '-p', dir }
+        [
+          config.local_base_path,
+          config.local_mirror_path,
+          config.local_releases_path,
+          config.local_archives_path,
+        ].each do |path|
+          execute :mkdir, '-p', path
+        end
       end
     end
   end

--- a/lib/capistrano/tasks/net_storage.rake
+++ b/lib/capistrano/tasks/net_storage.rake
@@ -116,7 +116,6 @@ namespace :net_storage do
         config.local_releases_path,
         config.local_archives_path,
       ]
-      dirs << config.local_bundle_path unless config.skip_bundle?
       run_locally do
         dirs.each { |dir| execute :mkdir, '-p', dir }
       end

--- a/lib/capistrano/tasks/net_storage.rake
+++ b/lib/capistrano/tasks/net_storage.rake
@@ -39,7 +39,6 @@ namespace :net_storage do
   task :sync_config do
     config = Capistrano::NetStorage.config
     Capistrano::NetStorage.scm.sync_config
-    Capistrano::NetStorage.bundler.sync_config unless config.skip_bundle?
   end
   after 'net_storage:create_release', 'net_storage:sync_config'
 

--- a/lib/capistrano/tasks/net_storage.rake
+++ b/lib/capistrano/tasks/net_storage.rake
@@ -145,4 +145,4 @@ namespace :net_storage do
   end
 end
 
-end
+end # end of prevent multiple loads

--- a/spec/capistrano/net_storage/config_spec.rb
+++ b/spec/capistrano/net_storage/config_spec.rb
@@ -23,8 +23,8 @@ describe Capistrano::NetStorage::Config do
       expect(config.executor_class(:archiver)).to be Capistrano::NetStorage::Archiver::Zip
       expect(config.executor_class(:scm)).to be Capistrano::NetStorage::SCM::Git
       expect(config.executor_class(:bundler)).to be Capistrano::NetStorage::Bundler
-      expect { config.executor_class(:transport) }.to raise_error(Capistrano::NetStorage::Error, /You have to set :net_storage_transport/)
-      expect { config.executor_class(:no_such_type) }.to raise_error(RuntimeError, /Unknown type!/)
+      expect { config.executor_class(:transport) }.to raise_error(ArgumentError, /You have to `set/)
+      expect { config.executor_class(:no_such_type) }.to raise_error(ArgumentError, /Invalid type/)
 
       # Others
       expect(config.servers.map(&:hostname)).to eq %w(web1 db1)

--- a/spec/capistrano/net_storage/config_spec.rb
+++ b/spec/capistrano/net_storage/config_spec.rb
@@ -34,6 +34,7 @@ describe Capistrano::NetStorage::Config do
       expect(config.archive_on_missing?).to be true
       expect(config.upload_files_by_rsync?).to be false
       expect(config.rsync_options).to eq({})
+      expect(config.multi_app_mode?).to be false
       expect(config.local_base_path.to_s).to eq "#{Dir.pwd}/.local_repo"
       expect(config.local_mirror_path.to_s).to eq "#{config.local_base_path}/mirror"
       expect(config.local_releases_path.to_s).to eq "#{config.local_base_path}/releases"
@@ -60,6 +61,7 @@ describe Capistrano::NetStorage::Config do
         net_storage_archive_on_missing: false,
         net_storage_upload_files_by_rsync: true,
         net_storage_rsync_options: { user: 'bob' },
+        net_storage_multi_app_mode: true,
         net_storage_local_base_path: '/path/to/local_base',
         net_storage_local_mirror_path: '/path/to/local_mirror',
         net_storage_local_releases_path: Pathname.new('/path/to/local_releases'),
@@ -82,6 +84,7 @@ describe Capistrano::NetStorage::Config do
       expect(config.archive_on_missing?).to be false
       expect(config.upload_files_by_rsync?).to be true
       expect(config.rsync_options).to eq(user: 'bob')
+      expect(config.multi_app_mode?).to be true
       expect(config.local_base_path.to_s).to eq '/path/to/local_base'
       expect(config.local_mirror_path.to_s).to eq '/path/to/local_mirror'
       expect(config.local_releases_path.to_s).to eq '/path/to/local_releases'

--- a/spec/capistrano/net_storage/config_spec.rb
+++ b/spec/capistrano/net_storage/config_spec.rb
@@ -2,9 +2,9 @@ require 'spec_helper'
 
 describe Capistrano::NetStorage::Config do
   let(:config) { Capistrano::NetStorage::Config.new }
+  let(:env) { Capistrano::Configuration.env } # Capistrano::NetStorage::Config fetches from global env
 
-  before :context do
-    env = Capistrano::Configuration.env
+  before do
     env.set :deploy_to, '/path/to/deploy'
     env.server 'web1', role: %w(web), active: true
     env.server 'web2', role: %w(web), no_release: true
@@ -13,7 +13,7 @@ describe Capistrano::NetStorage::Config do
     env.role :db,  %w(db1)
   end
 
-  after :context do
+  after do
     Capistrano::Configuration.reset!
   end
 
@@ -48,7 +48,6 @@ describe Capistrano::NetStorage::Config do
     it 'Customized parameters' do
       archiver_class = Struct.new(:file_extension).new('super.zip')
 
-      env = Capistrano::Configuration.env
       {
         net_storage_archiver: archiver_class,
         net_storage_scm: Object,

--- a/spec/capistrano/net_storage/config_spec.rb
+++ b/spec/capistrano/net_storage/config_spec.rb
@@ -46,9 +46,11 @@ describe Capistrano::NetStorage::Config do
     end
 
     it 'Customized parameters' do
+      archiver_class = Struct.new(:file_extension).new('super.zip')
+
       env = Capistrano::Configuration.env
       {
-        net_storage_archiver: Object,
+        net_storage_archiver: archiver_class,
         net_storage_scm: Object,
         net_storage_bundler: Object,
         net_storage_transport: Object,
@@ -68,7 +70,7 @@ describe Capistrano::NetStorage::Config do
       }.each { |k, v| env.set k, v }
 
       # executor_class
-      expect(config.executor_class(:archiver)).to be Object
+      expect(config.executor_class(:archiver)).to be archiver_class
       expect(config.executor_class(:scm)).to be Object
       expect(config.executor_class(:bundler)).to be Object
       expect(config.executor_class(:transport)).to be Object
@@ -87,9 +89,9 @@ describe Capistrano::NetStorage::Config do
       expect(config.local_release_path.to_s).to eq "#{config.local_releases_path}/#{config.release_timestamp}"
       expect(config.local_bundle_path.to_s).to eq '/path/to/local_bundle'
       expect(config.local_archives_path.to_s).to eq '/path/to/local_archives'
-      expect(config.local_archive_path.to_s).to eq "#{config.local_archives_path}/#{config.release_timestamp}.zip"
+      expect(config.local_archive_path.to_s).to eq "#{config.local_archives_path}/#{config.release_timestamp}.super.zip"
       expect(config.archives_path.to_s).to eq '/path/to/archives'
-      expect(config.archive_path.to_s).to eq "#{config.archives_path}/#{config.release_timestamp}.zip"
+      expect(config.archive_path.to_s).to eq "#{config.archives_path}/#{config.release_timestamp}.super.zip"
     end
   end
 end

--- a/spec/capistrano/net_storage/config_spec.rb
+++ b/spec/capistrano/net_storage/config_spec.rb
@@ -5,6 +5,7 @@ describe Capistrano::NetStorage::Config do
   let(:env) { Capistrano::Configuration.env } # Capistrano::NetStorage::Config fetches from global env
 
   before do
+    env.set :application, 'api'
     env.set :deploy_to, '/path/to/deploy'
     env.server 'web1', role: %w(web), active: true
     env.server 'web2', role: %w(web), no_release: true
@@ -35,10 +36,12 @@ describe Capistrano::NetStorage::Config do
       expect(config.upload_files_by_rsync?).to be false
       expect(config.rsync_options).to eq({})
       expect(config.multi_app_mode?).to be false
+      expect(config.release_app_path.to_s).to eq "/path/to/deploy/current" # SEE: https://github.com/capistrano/capistrano/blob/31e142d56f8d894f28404fb225dcdbe7539bda18/lib/capistrano/dsl/paths.rb#L21-L28
       expect(config.local_base_path.to_s).to eq "#{Dir.pwd}/.local_repo"
       expect(config.local_mirror_path.to_s).to eq "#{config.local_base_path}/mirror"
       expect(config.local_releases_path.to_s).to eq "#{config.local_base_path}/releases"
       expect(config.local_release_path.to_s).to eq "#{config.local_releases_path}/#{config.release_timestamp}"
+      expect(config.local_release_app_path.to_s).to eq "#{config.local_releases_path}/#{config.release_timestamp}"
       expect(config.local_bundle_path.to_s).to eq "#{config.local_base_path}/bundle"
       expect(config.local_archives_path.to_s).to eq "#{config.local_base_path}/archives"
       expect(config.local_archive_path.to_s).to eq "#{config.local_archives_path}/#{config.release_timestamp}.zip"
@@ -85,10 +88,12 @@ describe Capistrano::NetStorage::Config do
       expect(config.upload_files_by_rsync?).to be true
       expect(config.rsync_options).to eq(user: 'bob')
       expect(config.multi_app_mode?).to be true
+      expect(config.release_app_path.to_s).to eq "/path/to/deploy/current/api" # SEE: https://github.com/capistrano/capistrano/blob/31e142d56f8d894f28404fb225dcdbe7539bda18/lib/capistrano/dsl/paths.rb#L21-L28
       expect(config.local_base_path.to_s).to eq '/path/to/local_base'
       expect(config.local_mirror_path.to_s).to eq '/path/to/local_mirror'
       expect(config.local_releases_path.to_s).to eq '/path/to/local_releases'
       expect(config.local_release_path.to_s).to eq "#{config.local_releases_path}/#{config.release_timestamp}"
+      expect(config.local_release_app_path.to_s).to eq "#{config.local_releases_path}/#{config.release_timestamp}/api"
       expect(config.local_bundle_path.to_s).to eq '/path/to/local_bundle'
       expect(config.local_archives_path.to_s).to eq '/path/to/local_archives'
       expect(config.local_archive_path.to_s).to eq "#{config.local_archives_path}/#{config.release_timestamp}.super.zip"


### PR DESCRIPTION
### Summary

This update introduces a new feature allowing Capistrano::NetStorage to effectively manage and deploy multiple Rails applications within a single repository. This approach is particularly beneficial for rapid, cost-effective development processes.

Below is an example of the directory structure of a repository containing multiple Rails applications:

* sample_project
  * api_employee (Rails app)
    * app/controllers
    * Capfile
    * Gemfile
  * api_employer (Rails app)
    * app/controllers
    * Capfile
    * Gemfile
  * admin (Rails app)
    * ......

To utilize this feature, Capistrano::NetStorage users simply need to include the following line within their Capistrano configuration:

```ruby
set :net_storage_multi_app_mode, true
```

This command activates multi-app mode, enabling the tool to handle multiple Rails applications.

After the deployment, the directory structure would appear as follows:

* /deploy/to/api_employee
    * current
      * api_employee
    * releases
* /deploy/to/api_employer
    * current
      * api_employer
    * releases

In designing this feature, our main emphasis was on simplicity and maintainability, rather than customization of intricate details. Consequently, we have purposefully avoided including options specifically for this multi-app environment. The goal is to maintain a straightforward, easy-to-understand setup that aligns with our overarching philosophy of user-friendliness and codebase maintainability.

### Additional Details

This update includes a comprehensive assortment of bug fixes, code refactoring, and feature enhancements. Below is a summary of these improvements:

* `file_extension` has been successfully delegated to `:archiver`
* checking `local_bundle_path` is now successfully delegated to `:bundler`
* Deprecation warning of `bundle install --path` and other option is now properly handled via `bundle config set --local` command
* The `rsync` mechanism between cache directory (`local_bundle_path`) and install directory (`vendor/bundle`) is now more understandable by flat code design.
* `disable_shared_gems` are now explicitly handled at `bundle install` phase.
* Remove the need to overwrite `.bundle/config` by `sync_config`, which decreases code complexity and increases deployment speed.
* Refactor executor_class especially for default value.
* Remove caching at `Capistrano::NetStorage::Config` to avoid potential bug on changing values coming from `fetch(some_key)` such as `:release_path`
* Fix bug when `config_files` is an empty array
* Utilize Pathname ability to shorten code length and complexity

### Checklist

* [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).
