### PR TITLE
Make cleanup method for Transport layer mandatory

### DIFF
--- a/lib/capistrano/net_storage/transport/base.rb
+++ b/lib/capistrano/net_storage/transport/base.rb
@@ -31,9 +31,9 @@ module Capistrano
 
         # Clean up old archives on remote storage
         # @abstract
-        # def cleanup
-        #   raise NotImplementedError
-        # end
+        def cleanup
+          raise NotImplementedError
+        end
       end
     end
   end

--- a/lib/capistrano/tasks/net_storage.rake
+++ b/lib/capistrano/tasks/net_storage.rake
@@ -50,9 +50,7 @@ namespace :net_storage do
 
   desc 'Clean up old archive files on remote storage'
   task :cleanup_archives_on_remote_storage do
-    transport = Capistrano::NetStorage.transport
-    next unless transport.respond_to?(:cleanup)
-    transport.cleanup
+    Capistrano::NetStorage.transport.cleanup
   end
   after 'deploy:cleanup', 'net_storage:cleanup_archives_on_remote_storage'
 


### PR DESCRIPTION
### Summary

Since time has been passed, and cleanup is a must have feature for Transport layer,
we will make `Capistrano::NetStorage::Transport#cleanup` mandatory.

This also decreases code complexity.

Capistrano::NetStorage::S3 already supports this method.

### Other Information

### Checklist

* [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).
