### PR TITLE
Change default archiver from `.tar.gz` to `.zip`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Set Capistrano variables by `set name, value`.
  `:scm`  | `nil` | Set `:net_storage` for capistrano before v3.7
  `:branch` | `master` | Target branch of SCM to release
  `:keep_releases` | `5` | Numbers to keep released versions
- `:net_storage_archiver` | `Capistrano::NetStorage::Archiver::Zip` | Archiver class
+ `:net_storage_archiver` | `Capistrano::NetStorage::Archiver::TarGzip` | Archiver class
  `:net_storage_scm` | `Capistrano::NetStorage::SCM::Git` | Internal scm class for application repository
  `:net_storage_transport` | `nil` | Transport class for _remote storage_
  `:net_storage_archive_on_missing` | `true` | If `true`, create and upload archive only when target archive is missing on remote storage

--- a/lib/capistrano/net_storage/config.rb
+++ b/lib/capistrano/net_storage/config.rb
@@ -1,7 +1,7 @@
 require 'pathname'
 
 require 'capistrano/net_storage/bundler'
-require 'capistrano/net_storage/archiver/zip'
+require 'capistrano/net_storage/archiver/tar_gzip'
 require 'capistrano/net_storage/scm/git'
 require 'capistrano/net_storage/cleaner'
 require 'capistrano/net_storage/bundler'
@@ -10,7 +10,7 @@ module Capistrano
   module NetStorage
     class Config
       DEFAULT_EXECUTOR_CLASS = {
-        archiver: Capistrano::NetStorage::Archiver::Zip,
+        archiver: Capistrano::NetStorage::Archiver::TarGzip,
         scm: Capistrano::NetStorage::SCM::Git,
         cleaner: Capistrano::NetStorage::Cleaner,
         bundler: Capistrano::NetStorage::Bundler,

--- a/spec/capistrano/net_storage/config_spec.rb
+++ b/spec/capistrano/net_storage/config_spec.rb
@@ -21,7 +21,7 @@ describe Capistrano::NetStorage::Config do
   describe 'Configuration params' do
     it 'Default parameters' do
       # executor_class
-      expect(config.executor_class(:archiver)).to be Capistrano::NetStorage::Archiver::Zip
+      expect(config.executor_class(:archiver)).to be Capistrano::NetStorage::Archiver::TarGzip
       expect(config.executor_class(:scm)).to be Capistrano::NetStorage::SCM::Git
       expect(config.executor_class(:bundler)).to be Capistrano::NetStorage::Bundler
       expect { config.executor_class(:transport) }.to raise_error(ArgumentError, /You have to `set/)
@@ -44,9 +44,9 @@ describe Capistrano::NetStorage::Config do
       expect(config.local_release_app_path.to_s).to eq "#{config.local_releases_path}/#{config.release_timestamp}"
       expect(config.local_bundle_path.to_s).to eq "#{config.local_base_path}/bundle"
       expect(config.local_archives_path.to_s).to eq "#{config.local_base_path}/archives"
-      expect(config.local_archive_path.to_s).to eq "#{config.local_archives_path}/#{config.release_timestamp}.zip"
+      expect(config.local_archive_path.to_s).to eq "#{config.local_archives_path}/#{config.release_timestamp}.tar.gz"
       expect(config.archives_path.to_s).to eq "#{config.deploy_path}/net_storage_archives"
-      expect(config.archive_path.to_s).to eq "#{config.archives_path}/#{config.release_timestamp}.zip"
+      expect(config.archive_path.to_s).to eq "#{config.archives_path}/#{config.release_timestamp}.tar.gz"
     end
 
     it 'Customized parameters' do


### PR DESCRIPTION
### Summary

As `.tar.gz` is more suitable for keeping file attributes (uid, gid, permissions...),
we change the default archive format from `.zip` to `.tar.gz`.

Since we are using `.tar.gz` on everyday deployment,
changing the default increases the maintainability of this software.

This breaking change is to be released in the next version 1.0.0.

### Other Information

### Checklist

* [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).
