### PR TITLE
Change default of :net_storage_config_files from `nil` to `[]` (empty array)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Set Capistrano variables by `set name, value`.
  `:net_storage_scm` | `Capistrano::NetStorage::SCM::Git` | Internal scm class for application repository
  `:net_storage_transport` | `nil` | Transport class for _remote storage_
  `:net_storage_archive_on_missing` | `true` | If `true`, create and upload archive only when target archive is missing on remote storage
- `:net_storage_config_files` | `nil` | Files to sync `config/` directory on target servers' application directory
+ `:net_storage_config_files` | `[]` | Files to sync `config/` directory on target servers' application directory
  `:net_storage_max_parallels` | number of servers | Max concurrency for remote tasks
  `:net_storage_rsync_options` | `#{ssh_options}` | SSH options for rsync command to sync configs
  `:net_storage_upload_files_by_rsync` | `false` | Use rsync(1) to deploy config files

--- a/lib/capistrano/net_storage/config.rb
+++ b/lib/capistrano/net_storage/config.rb
@@ -45,7 +45,7 @@ module Capistrano
       # Application configuration files to be deployed with
       # @return [Array<String, Pathname>]
       def config_files
-        fetch(:net_storage_config_files)
+        fetch(:net_storage_config_files, [])
       end
 
       # If +true+, skip to bundle gems bundled with target app.

--- a/lib/capistrano/net_storage/scm/base.rb
+++ b/lib/capistrano/net_storage/scm/base.rb
@@ -40,7 +40,7 @@ module Capistrano
 
         # Copy local config files to servers
         def sync_config
-          return unless config.config_files&.any?
+          return if config.config_files.empty?
 
           upload_files(config.config_files, config.release_app_path.join('config'))
         end

--- a/spec/capistrano/net_storage/config_spec.rb
+++ b/spec/capistrano/net_storage/config_spec.rb
@@ -30,7 +30,7 @@ describe Capistrano::NetStorage::Config do
       # Others
       expect(config.servers.map(&:hostname)).to eq %w(web1 db1)
       expect(config.max_parallels).to eq 2
-      expect(config.config_files).to be nil
+      expect(config.config_files).to eq []
       expect(config.skip_bundle?).to be true
       expect(config.archive_on_missing?).to be true
       expect(config.upload_files_by_rsync?).to be false


### PR DESCRIPTION
### Summary

This patch changes the default of `:net_storage_config_files` from `nil` to `[]`.
This reduces the code complexity, and improves the understandability on what is to be assigned to `:net_storage_config_files`

### Other Information

### Checklist

* [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).
