### PR TITLE
Introduce :net_storage_keep_remote_archives with improved documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ namespace :your_namespace do
       within Capistrano::NetStorage.config.local_release_app_path do
         # The resultant artifacts are to be archived with other files
         execute :bundle, 'exec', 'rake', 'build_in_memory_cache_bundle'
+        execute :bundle, 'exec', 'rake', 'assets:precompile'
       end
     end
   end

--- a/README.md
+++ b/README.md
@@ -135,11 +135,6 @@ end
 after 'net_storage:prepare_archive', 'your_namespace:prepare_archive'
 ```
 
-## Example
-
-You can see typical usage of this library by
-[capistrano-net_storage_demo](https://github.com/DeNADev/capistrano-net_storage_demo).
-
 ## License
 
 Available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).

--- a/README.md
+++ b/README.md
@@ -50,20 +50,34 @@ You can consult configuration of Capistrano itself at https://capistranorb.com/d
 
 Configurations of Capistrano::NetStorage are as follows:
 
+#### General Settings
+
  Name | Default | Description
 ------|---------|------------
  `:net_storage_transport` | NO DEFAULT | Transport class for _remote storage_ e.g. `Capistrano::NetStorage::S3`
+ `:net_storage_config_files` | `[]` | Files to sync `config/` directory on target servers' application directory
+
+#### Settings for Behavioral Changes
+
+ Name | Default | Description
+------|---------|------------
+ `:net_storage_skip_bundle` | `false` | Skip `bundle install` when creating archive (might be work for non-Ruby app)
+ `:net_storage_multi_app_mode` | `false` | Deploy a repository with multiple Rails apps at the top directory
+
+#### Other Settings
+
+**NOTE: We strongly recommend the defaults for integrity and performance. Change at your own risk.**
+
+ Name | Default | Description
+------|---------|------------
  `:net_storage_archiver` | `Capistrano::NetStorage::Archiver::TarGzip` | Archiver class
  `:net_storage_scm` | `Capistrano::NetStorage::SCM::Git` | Internal scm class for application repository
- `:net_storage_config_files` | `[]` | Files to sync `config/` directory on target servers' application directory
  `:net_storage_upload_files_by_rsync` | `true` | Use rsync(1) to deploy config files
  `:net_storage_rsync_options` | `#{ssh_options}` | SSH options for rsync command to sync configs
  `:net_storage_max_parallels` | 1000 | Max concurrency for remote tasks. (This default is being tuned by maintainers.)
  `:net_storage_reuse_archive` | `true` | If `true`, it reuses archive with the same commit hash at remote storage and uploads archives only when it does not exist.
  `:net_storage_local_base_path` | `.local_net_storage` | Base directory on deploy server
  `:net_storage_archives_path` | `#{deploy_to}/net_storage_archives` | Archive directories on application server
- `:net_storage_skip_bundle` | `false` | Skip `bundle install` when creating archive
- `:net_storage_multi_app_mode` | `false` | Deploy a repository with multiple Rails apps at the top directory
 
 ### Transport Plugins
 

--- a/README.md
+++ b/README.md
@@ -16,11 +16,12 @@ The image below illustrates the concept of **Capistrano::NetStorage**.
 
 ![concept](docs/images/concept.png)
 
-This library goes following procedures as _capistrano tasks_:
+This library conducts the following procedures as _capistrano tasks_:
 
 1. Prepare an archive of application to upload.
-  * Clone or update source code repository on deploy server.
-  * Do `bundle install` by an option.
+  * Clone and update source code repository on deploy server.
+  * Extract the internals to local release directory.
+  * Further prepare the local release. (e.g. `bundle install` and `assets:precompile`)
 2. Upload the archive to _remote storage_.
 3. Download the archive from _remote storage_ on application servers.
   * This task is executed in parallel way.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Configurations of Capistrano::NetStorage are as follows:
  `:net_storage_reuse_archive` | `true` | If `true`, it reuses archive with the same commit hash at remote storage and uploads archives only when it does not exist.
  `:net_storage_local_base_path` | `.local_net_storage` | Base directory on deploy server
  `:net_storage_archives_path` | `#{deploy_to}/net_storage_archives` | Archive directories on application server
+ `:net_storage_keep_remote_archives` | 10 | Number of archive files keep on remote storage
 
 ### Transport Plugins
 

--- a/lib/capistrano/net_storage/config.rb
+++ b/lib/capistrano/net_storage/config.rb
@@ -63,6 +63,10 @@ module Capistrano
         fetch(:net_storage_reuse_archive)
       end
 
+      def keep_remote_archives
+        fetch(:net_storage_keep_remote_archives)
+      end
+
       # Settings for behavioral changes
 
       def skip_bundle?

--- a/lib/capistrano/net_storage/plugin.rb
+++ b/lib/capistrano/net_storage/plugin.rb
@@ -26,6 +26,8 @@ module Capistrano
 
         set_if_empty :net_storage_skip_bundle, false
         set_if_empty :net_storage_multi_app_mode, false
+
+        set_if_empty :net_storage_keep_remote_archives, 10
       end
 
       def define_tasks

--- a/spec/capistrano/net_storage/config_spec.rb
+++ b/spec/capistrano/net_storage/config_spec.rb
@@ -41,6 +41,7 @@ describe Capistrano::NetStorage::Config do
 
           max_parallels: 1000,
           reuse_archive?: true,
+          keep_remote_archives: 10,
 
           local_base_path: Pathname.new("#{Dir.pwd}/.local_net_storage"),
           archives_path: Pathname.new('/path/to/deploy/net_storage_archives'),
@@ -100,6 +101,7 @@ describe Capistrano::NetStorage::Config do
 
           set :net_storage_max_parallels, 777
           set :net_storage_reuse_archive, false
+          set :net_storage_keep_remote_archives, 1000
 
           set :net_storage_local_base_path, 'hoge'
 
@@ -118,6 +120,7 @@ describe Capistrano::NetStorage::Config do
 
           max_parallels: 777,
           reuse_archive?: false,
+          keep_remote_archives: 1000,
 
           local_base_path: Pathname.new('hoge'),
 


### PR DESCRIPTION
### Summary

In general, storage cost on remote storage such as S3 and GCS
is much smaller than that on local storage.
We can utilize these characteristics by separating the number of
keep archives on remote (:net_storage_keep_remote_archives) from
keep releases on local (:keep_releases)
The default number is set to 10 which is a reasonable number from our experience.

### Other Information

I have improved README as follows:

* Remove link to unmaintained example.
  * We can just provide example Capfile and deploy.rb at README.md
* Split settings into 3 sections
  * Almost all the users does not have to change the minute details of Capistrano::NetStorage
  * Rather, changing some parameters could result in a bug or performance issue.
* Improve document on deployment flow


### Checklist

* [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).
