### PR TITLE
Improve comment and error message to make debugging more efficient

### DIFF
--- a/lib/capistrano/net_storage/archiver/base.rb
+++ b/lib/capistrano/net_storage/archiver/base.rb
@@ -1,31 +1,22 @@
 module Capistrano
   module NetStorage
     module Archiver
-      # Abstract class to archive and extract whole application contents
-      # @abstract
+      # Abstract class to archive release in local and extract release in remote
       class Base
-        # Check prerequisites to archive
-        # @abstract
         def check
-          raise NotImplementedError
+          raise NotImplementedError, "Implement `#{self.class}#{__method__}` to check prerequisites for Archiver"
         end
 
-        # Create archive
-        # @abstract
         def archive
-          raise NotImplementedError
+          raise NotImplementedError, "Implement `#{self.class}#{__method__}` to create archive from `Capistrano::NetStorage.config.local_release_path` to `Capistrano::NetStorage.config.local_archive_path`"
         end
 
-        # Extract archive
-        # @abstract
         def extract
-          raise NotImplementedError
+          raise NotImplementedError, "Implement `#{self.class}#{__method__}` to extract archive from `Capistrano::NetStorage.config.archive_path` to `release_path`"
         end
 
-        # file extension
-        # @abstract
         def self.file_extension
-          raise NotImplementedError
+          raise NotImplementedError, "Implement `#{self.class}#{__method__}` to return file extension String such as 'zip' or 'tar.gz'"
         end
       end
     end

--- a/lib/capistrano/net_storage/archiver/tar_gzip.rb
+++ b/lib/capistrano/net_storage/archiver/tar_gzip.rb
@@ -22,7 +22,6 @@ class Capistrano::NetStorage::Archiver::TarGzip < Capistrano::NetStorage::Archiv
     config = Capistrano::NetStorage.config
 
     on release_roles(:all), in: :groups, limit: config.max_parallels do
-      execute :mkdir, '-p', config.archives_path
       execute :mkdir, '-p', release_path
       within release_path do
         execute :tar, 'xzf', config.archive_path

--- a/lib/capistrano/net_storage/scm/base.rb
+++ b/lib/capistrano/net_storage/scm/base.rb
@@ -2,36 +2,25 @@ module Capistrano
   module NetStorage
     module SCM
       # Base internal SCM class of Capistrano::Netstrage
-      # @abstract
       class Base
-        # Check SCM prerequisites
-        # @abstract
         def check
-          raise NotImplementedError
+          raise NotImplementedError, "Implement `#{self.class}#{__method__}` to check prerequisites for SCM"
         end
 
-        # Clone repository to local
-        # @abstract
         def clone
-          raise NotImplementedError
+          raise NotImplementedError, "Implement `#{self.class}#{__method__}` to clone repository to `Capistrano::NetStorage.config.local_mirror_path`"
         end
 
-        # Update local repository
-        # @abstract
         def update
-          raise NotImplementedError
+          raise NotImplementedError, "Implement `#{self.class}#{__method__}` to update repository in `Capistrano::NetStorage.config.local_mirror_path`"
         end
 
-        # Set current revision to be deployed of the repository
-        # @abstract
         def set_current_revision
-          raise NotImplementedError
+          raise NotImplementedError, "Implement `#{self.class}#{__method__}` to set current revision by `set :current_revision, revision`"
         end
 
-        # Prepare snapshot of repository to be archived for release
-        # @abstract
         def prepare_archive
-          raise NotImplementedError
+          raise NotImplementedError, "Implement `#{self.class}#{__method__}` to extract and prepare release into `Capistrano::NetStorage.config.local_release_path`"
         end
       end
     end

--- a/lib/capistrano/net_storage/scm/base.rb
+++ b/lib/capistrano/net_storage/scm/base.rb
@@ -1,7 +1,7 @@
 module Capistrano
   module NetStorage
     module SCM
-      # Base internal SCM class of Capistrano::Netstrage
+      # Abstract class to handle SCM between local_mirror_path and local_release_path
       class Base
         def check
           raise NotImplementedError, "Implement `#{self.class}#{__method__}` to check prerequisites for SCM"

--- a/lib/capistrano/net_storage/scm/git.rb
+++ b/lib/capistrano/net_storage/scm/git.rb
@@ -1,6 +1,5 @@
 require 'capistrano/net_storage/scm/base'
 
-# Internal SCM class for Git repository
 class Capistrano::NetStorage::SCM::Git < Capistrano::NetStorage::SCM::Base
   def check
     run_locally do

--- a/lib/capistrano/net_storage/transport/base.rb
+++ b/lib/capistrano/net_storage/transport/base.rb
@@ -1,38 +1,30 @@
 module Capistrano
   module NetStorage
     module Transport
-      # Abstract class to transport archive from/to remote storage
-      # @abstract
+      # Abstract class to upload archive from local to storage and download from storage to remote
       class Base
-        # Check prerequisites for transport
-        # @abstract
         def check
-          raise NotImplementedError
+          raise NotImplementedError, "Implement `#{self.class}#{__method__}` to check prerequisites for Transport"
         end
 
         # Return whether or not archive is already exist on remote storage
         # @abstract
         def archive_exists?
-          raise NotImplementedError
+          raise NotImplementedError, "Implement `#{self.class}#{__method__}` to test archive on storage corresponding to `fetch(:current_revision) + Config#archive_file_extension`"
         end
 
         # Upload archive onto remote storage
         # @abstract
         def upload
-          raise NotImplementedError
+          raise NotImplementedError, "Implement `#{self.class}#{__method__}` to upload archive from `Capistrano::NetStorage.config.local_archive_path` to remote storage"
         end
 
-        # Download archive from remote storage to servers.
-        # Archive file should be placed at +config.archive_path+
-        # @abstract
         def download
-          raise NotImplementedError
+          raise NotImplementedError, "Implement `#{self.class}#{__method__}` to download archive from remote storage to `Capistrano::NetStorage.config.archive_path`"
         end
 
-        # Clean up old archives on remote storage
-        # @abstract
         def cleanup
-          raise NotImplementedError
+          raise NotImplementedError, "Implement `#{self.class}#{__method__}` to clean archives on remote storage to `Capistrano::NetStorage.config.keep_remote_archives`"
         end
       end
     end


### PR DESCRIPTION
### Summary

Sometimes when executing deployment by `cap production deploy`, we encounter following errors:

```
(Backtrace restricted to imported tasks)
cap aborted!
NotImplementedError: NotImplementedError

Tasks: TOP => net_storage:create_release
(See full trace by running task with --trace)
The deploy has failed with an error: NotImplementedError
```

This is due to the imperfect implementation of Capistrano::NetStorage::Transport plugins. (custom plugin)
Although we can dig into the details by appending `--trace` and viewing the buggy code, this is time-consuming.

By adding appropriate exception message, the debugging will be more efficient.

Also, I have integrated the comment to the error message.

### Other Information

### Checklist

* [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).
