### PR TITLE
Allow Capistrano::NetStorage to deploy different Ruby versions

### DIFF
--- a/lib/capistrano/net_storage/bundler/default.rb
+++ b/lib/capistrano/net_storage/bundler/default.rb
@@ -20,23 +20,31 @@ module Capistrano
           run_locally do
             within config.local_release_app_path do
               ::Bundler.with_unbundled_env do
-                install_path = Pathname.new('vendor/bundle') # must be a relative path for portability between local and remote
-                execute :mkdir, '-p', install_path
+                with rbenv_version: nil, rbenv_dir: nil do
+                  bundle = if test :rbenv, 'version'
+                    %w[rbenv exec bundle]
+                  else
+                    %w[bundle]
+                  end
 
-                # Sync installed gems from shared directory to speed up installation
-                execute :rsync, '-a', '--delete', "#{config.local_bundle_path}/", install_path
+                  install_path = Pathname.new('vendor/bundle') # must be a relative path for portability between local and remote
+                  execute :mkdir, '-p', install_path
 
-                # Always set config
-                execute :bundle, 'config', 'set', '--local', 'deployment', 'true'
-                execute :bundle, 'config', 'set', '--local', 'path', install_path
-                execute :bundle, 'config', 'set', '--local', 'without', 'development test'
-                execute :bundle, 'config', 'set', '--local', 'disable_shared_gems', 'true'
+                  # Sync installed gems from shared directory to speed up installation
+                  execute :rsync, '-a', '--delete', "#{config.local_bundle_path}/", install_path
 
-                execute :bundle, 'install', '--quiet'
-                execute :bundle, 'clean'
+                  # Always set config
+                  execute *bundle, 'config', 'set', '--local', 'deployment', 'true'
+                  execute *bundle, 'config', 'set', '--local', 'path', install_path
+                  execute *bundle, 'config', 'set', '--local', 'without', 'development test'
+                  execute *bundle, 'config', 'set', '--local', 'disable_shared_gems', 'true'
 
-                # Sync back to shared directory for the next release
-                execute :rsync, '-a', '--delete', "#{install_path}/", config.local_bundle_path
+                  execute *bundle, 'install', '--quiet'
+                  execute *bundle, 'clean'
+
+                  # Sync back to shared directory for the next release
+                  execute :rsync, '-a', '--delete', "#{install_path}/", config.local_bundle_path
+                end
               end
             end
           end


### PR DESCRIPTION
## Background

When we are updating Ruby version of a Repository by `.ruby-version` of `rbenv`, we have found out that `bundle` command does not work as expected.

This occurs when there is a difference of Ruby version between deploying application version and deployed application version.

Let's assume we have a repository with Ruby 3.0.6, and we are deploying an old version of the same repository with Ruby 2.6.2. In this case, the current `bundle` is being run from Ruby 3.0.6, which is not an intended behavior.

## How we have fixed 

Fixing this issue is divided into 2 phase.

* Clearing environment variables of `RBENV_VERSION` and `RBENV_DIR`
  * In order to forget current ruby version, `RBENV_VERSION` is cleared.
  * In order to correctly search `.ruby-version`, `RBENV_DIR` is cleared.
  * https://github.com/rbenv/rbenv#environment-variables
* Prepend `rbenv exec` when it works
  * For backward compatibility, we only append `rbenv exec` when `rbenv version` is successful

## Other considerations to this patch

Since `rbenv` and `.ruby-version` is a de facto standard of Ruby ecosystem in 2023 and we are using them in production, this patch focuses only on `rbenv`.

Prepending `rbenv exec` to specific commands in Capistrano is usually achieved by `capistrano-rbenv`. However, this only affects `SSHKit.config.command_map`, which is effective only on remote command execution. Considering the local execution flow of `capistrano-bundle_rsync`, I thought it is rational to directly prepending `rbenv exec` here.
https://github.com/capistrano/rbenv#usage

### Checklist

* [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).
